### PR TITLE
Server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,17 @@
         <dependency>
             <groupId>org.intellimate.izou</groupId>
             <artifactId>izou</artifactId>
-            <version>1.15.6</version>
+            <version>1.16.1</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.24-incubating</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.intellimate.izou</groupId>
             <artifactId>izou</artifactId>
-            <version>1.16.1</version>
+            <version>1.16.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.intellimate.izou</groupId>
             <artifactId>izou</artifactId>
-            <version>1.16.2</version>
+            <version>1.16.3</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.intellimate.izou</groupId>
     <artifactId>sdk</artifactId>
-    <version>0.18.2</version>
+    <version>0.19.0</version>
     <name>IzouSDK</name>
     <description>the sdk used to program for izou</description>
     <url>https://github.com/intellimate/IzouSDK</url>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.intellimate.izou</groupId>
             <artifactId>izou</artifactId>
-            <version>1.16.4</version>
+            <version>1.16.5</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.intellimate.izou</groupId>
             <artifactId>izou</artifactId>
-            <version>1.16.3</version>
+            <version>1.16.4</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/main/java/org/intellimate/izou/sdk/AddOnImpl.java
+++ b/src/main/java/org/intellimate/izou/sdk/AddOnImpl.java
@@ -9,12 +9,14 @@ import org.intellimate.izou.output.OutputPluginModel;
 import org.intellimate.izou.sdk.addon.AddOn;
 import org.intellimate.izou.sdk.contentgenerator.ContentGenerator;
 import org.intellimate.izou.sdk.server.SDKRouter;
+import ro.fortsoft.pf4j.Extension;
 
 /**
  * @author LeanderK
  * @version 1.0
  */
-@SuppressWarnings("WeakerAccess")
+@Extension
+@SuppressWarnings({"WeakerAccess", "unused"})
 public class AddOnImpl extends AddOn {
     public AddOnImpl() {
         super(AddOnImpl.class.getCanonicalName());

--- a/src/main/java/org/intellimate/izou/sdk/AddOnImpl.java
+++ b/src/main/java/org/intellimate/izou/sdk/AddOnImpl.java
@@ -1,0 +1,60 @@
+package org.intellimate.izou.sdk;
+
+
+import org.intellimate.izou.activator.ActivatorModel;
+import org.intellimate.izou.events.EventsControllerModel;
+import org.intellimate.izou.output.OutputControllerModel;
+import org.intellimate.izou.output.OutputExtensionModel;
+import org.intellimate.izou.output.OutputPluginModel;
+import org.intellimate.izou.sdk.addon.AddOn;
+import org.intellimate.izou.sdk.contentgenerator.ContentGenerator;
+import org.intellimate.izou.sdk.server.SDKRouter;
+
+/**
+ * @author LeanderK
+ * @version 1.0
+ */
+@SuppressWarnings("WeakerAccess")
+public class AddOnImpl extends AddOn {
+    public AddOnImpl() {
+        super(AddOnImpl.class.getCanonicalName());
+    }
+
+    /**
+     * This method gets called before registering
+     */
+    @Override
+    public void prepare() {
+        setRouter(new SDKRouter(getContext()));
+    }
+
+    @Override
+    public ActivatorModel[] registerActivator() {
+        return new ActivatorModel[0];
+    }
+
+    @Override
+    public ContentGenerator[] registerContentGenerator() {
+        return new ContentGenerator[0];
+    }
+
+    @Override
+    public EventsControllerModel[] registerEventController() {
+        return new EventsControllerModel[0];
+    }
+
+    @Override
+    public OutputPluginModel[] registerOutputPlugin() {
+        return new OutputPluginModel[0];
+    }
+
+    @Override
+    public OutputExtensionModel[] registerOutputExtension() {
+        return new OutputExtensionModel[0];
+    }
+
+    @Override
+    public OutputControllerModel[] registerOutputController() {
+        return new OutputControllerModel[0];
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/Context.java
+++ b/src/main/java/org/intellimate/izou/sdk/Context.java
@@ -145,6 +145,16 @@ public class Context implements org.intellimate.izou.system.Context {
         return context.getAddOns();
     }
 
+    /**
+     * Returns the API, which contains information bout to the server and the connection
+     *
+     * @return ServerInformation
+     */
+    @Override
+    public ServerInformation getServerInformation() {
+        return context.getServerInformation();
+    }
+
     private class ContentGeneratorsImpl implements ContentGenerators {
 
         /**

--- a/src/main/java/org/intellimate/izou/sdk/addon/AddOn.java
+++ b/src/main/java/org/intellimate/izou/sdk/addon/AddOn.java
@@ -11,7 +11,6 @@ import org.intellimate.izou.sdk.Context;
 import org.intellimate.izou.sdk.contentgenerator.ContentGenerator;
 import org.intellimate.izou.sdk.output.OutputController;
 import org.intellimate.izou.sdk.output.OutputExtension;
-import org.intellimate.izou.sdk.server.Response;
 import org.intellimate.izou.sdk.server.Router;
 import org.intellimate.izou.sdk.server.properties.PropertiesRouter;
 import org.intellimate.izou.sdk.util.ContextProvider;
@@ -19,8 +18,6 @@ import org.intellimate.izou.sdk.util.Loggable;
 import org.intellimate.izou.sdk.util.LoggedExceptionCallback;
 import org.intellimate.izou.server.Request;
 import ro.fortsoft.pf4j.PluginWrapper;
-
-import static com.sun.xml.internal.ws.api.message.Packet.Status.Response;
 
 /**
  * All AddOns must extend this Class.

--- a/src/main/java/org/intellimate/izou/sdk/addon/AddOn.java
+++ b/src/main/java/org/intellimate/izou/sdk/addon/AddOn.java
@@ -13,6 +13,7 @@ import org.intellimate.izou.sdk.output.OutputController;
 import org.intellimate.izou.sdk.output.OutputExtension;
 import org.intellimate.izou.sdk.server.Response;
 import org.intellimate.izou.sdk.server.Router;
+import org.intellimate.izou.sdk.server.properties.PropertiesRouter;
 import org.intellimate.izou.sdk.util.ContextProvider;
 import org.intellimate.izou.sdk.util.Loggable;
 import org.intellimate.izou.sdk.util.LoggedExceptionCallback;
@@ -47,6 +48,7 @@ public abstract class AddOn implements AddOnModel, ContextProvider, Loggable, Lo
      */
     @Override
     public void register() {
+        this.router = new PropertiesRouter(getContext());
         prepare();
         ContentGenerator[] contentGenerators = registerContentGenerator();
         if (contentGenerators != null) {

--- a/src/main/java/org/intellimate/izou/sdk/addon/AddOn.java
+++ b/src/main/java/org/intellimate/izou/sdk/addon/AddOn.java
@@ -11,10 +11,15 @@ import org.intellimate.izou.sdk.Context;
 import org.intellimate.izou.sdk.contentgenerator.ContentGenerator;
 import org.intellimate.izou.sdk.output.OutputController;
 import org.intellimate.izou.sdk.output.OutputExtension;
+import org.intellimate.izou.sdk.server.Response;
+import org.intellimate.izou.sdk.server.Router;
 import org.intellimate.izou.sdk.util.ContextProvider;
 import org.intellimate.izou.sdk.util.Loggable;
 import org.intellimate.izou.sdk.util.LoggedExceptionCallback;
+import org.intellimate.izou.server.Request;
 import ro.fortsoft.pf4j.PluginWrapper;
+
+import static com.sun.xml.internal.ws.api.message.Packet.Status.Response;
 
 /**
  * All AddOns must extend this Class.
@@ -26,6 +31,7 @@ public abstract class AddOn implements AddOnModel, ContextProvider, Loggable, Lo
     private final String addOnID;
     private Context context;
     private PluginWrapper plugin;
+    private Router router;
 
     /**
      * The default constructor for AddOns
@@ -188,6 +194,29 @@ public abstract class AddOn implements AddOnModel, ContextProvider, Loggable, Lo
     @Override
     public PluginWrapper getPlugin() {
         return plugin;
+    }
+
+    /**
+     * sets the router to use when handling requests
+     * @param router the router to use
+     */
+    @SuppressWarnings("unused")
+    protected void setRouter(Router router) {
+        this.router = router;
+    }
+
+    /**
+     * this method handles the HTTP-Requests from the server.
+     * <p>
+     * this method should not be overridden, to change behaviour please user setRouter.
+     * <p>
+     *
+     * @param request the request to process
+     * @return the response
+     */
+    @Override
+    public org.intellimate.izou.server.Response handleRequest(Request request) {
+        return router.handle(request);
     }
 
     /**

--- a/src/main/java/org/intellimate/izou/sdk/server/BadRequestException.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/BadRequestException.java
@@ -1,11 +1,11 @@
 package org.intellimate.izou.sdk.server;
 
 /**
- * represents a 404 NotFound
+ * represents an BadRequest (400)
  * @author LeanderK
  * @version 1.0
  */
-public class NotFoundException extends RuntimeException {
+public class BadRequestException extends RuntimeException {
     /**
      * Constructs a new runtime exception with the specified detail message.
      * The cause is not initialized, and may subsequently be initialized by a
@@ -14,19 +14,8 @@ public class NotFoundException extends RuntimeException {
      * @param message the detail message. The detail message is saved for
      *                later retrieval by the {@link #getMessage()} method.
      */
-    public NotFoundException(String message) {
+    public BadRequestException(String message) {
         super(message);
-    }
-
-    /**
-     * Constructs a new runtime exception with the specified detail message.
-     * The cause is not initialized, and may subsequently be initialized by a
-     * call to {@link #initCause}.
-     *
-     * @param request the request not found
-     */
-    public NotFoundException(Request request) {
-        super(request.getUrl() + " not found");
     }
 
     /**
@@ -43,7 +32,7 @@ public class NotFoundException extends RuntimeException {
      *                unknown.)
      * @since 1.4
      */
-    public NotFoundException(String message, Throwable cause) {
+    public BadRequestException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/org/intellimate/izou/sdk/server/DefaultHandler.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/DefaultHandler.java
@@ -14,9 +14,11 @@ import java.util.function.Function;
  * @author LeanderK
  * @version 1.0
  */
+@SuppressWarnings("WeakerAccess")
 public class DefaultHandler extends AddOnModule implements Handler, FireEvent {
     private final Method method;
     private final Function<Request, Response> function;
+    private final boolean internal;
 
     /**
      * initializes the Module
@@ -24,15 +26,19 @@ public class DefaultHandler extends AddOnModule implements Handler, FireEvent {
      * @param method the registered method
      * @param function the function to execute
      */
-    public DefaultHandler(Context context, String addOnPackageName, String route, Method method, Function<Request, Response> function) {
+    public DefaultHandler(Context context, String addOnPackageName, String route, Method method, boolean internal, Function<Request, Response> function) {
         super(context, addOnPackageName+"."+route+method.name());
         this.method = method;
         this.function = function;
+        this.internal = internal;
     }
 
     @Override
     public Optional<Response> handle(Request request) {
         if (!request.getMethod().toLowerCase().equals(method.name().toLowerCase())) {
+            return Optional.empty();
+        }
+        if (internal && !request.getToken().isPresent()) {
             return Optional.empty();
         }
         Response response = function.apply(request);

--- a/src/main/java/org/intellimate/izou/sdk/server/DefaultHandler.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/DefaultHandler.java
@@ -1,0 +1,44 @@
+package org.intellimate.izou.sdk.server;
+
+import org.intellimate.izou.sdk.Context;
+import org.intellimate.izou.sdk.util.AddOnModule;
+import org.intellimate.izou.sdk.util.FireEvent;
+import org.intellimate.izou.util.IzouModule;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+/**
+ * handles a request on a specific route
+ * @author LeanderK
+ * @version 1.0
+ */
+public class DefaultHandler extends AddOnModule implements Handler, FireEvent {
+    private final Method method;
+    private final Function<Request, Response> function;
+
+    /**
+     * initializes the Module
+     * @param context the current context
+     * @param method the registered method
+     * @param function the function to execute
+     */
+    public DefaultHandler(Context context, String addOnPackageName, String route, Method method, Function<Request, Response> function) {
+        super(context, addOnPackageName+"."+route+method.name());
+        this.method = method;
+        this.function = function;
+    }
+
+    @Override
+    public Optional<Response> handle(Request request) {
+        if (!request.getMethod().toLowerCase().equals(method.name().toLowerCase())) {
+            return Optional.empty();
+        }
+        Response response = function.apply(request);
+        if (response == null  || !response.isValidResponse()) {
+            throw new InternalServerErrorException("App returned illegal response");
+        }
+        return Optional.of(response);
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/Handler.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Handler.java
@@ -1,0 +1,17 @@
+package org.intellimate.izou.sdk.server;
+
+import java.util.Optional;
+
+/**
+ * handles a request on a specific route
+ * @author LeanderK
+ * @version 1.0
+ */
+public interface Handler extends HandlerHelper {
+    /**
+     * maybe handles a request
+     * @param request the request
+     * @return empty if not responsible for the request or response
+     */
+    Optional<Response> handle(Request request);
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/HandlerHelper.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/HandlerHelper.java
@@ -1,10 +1,10 @@
 package org.intellimate.izou.sdk.server;
 
+import org.intellimate.izou.identification.AddOnInformation;
 import org.intellimate.izou.sdk.Context;
-import org.intellimate.izou.sdk.util.ContextProvider;
 
-import java.nio.charset.Charset;
 import java.util.HashMap;
+import java.util.Optional;
 
 /**
  * @author LeanderK
@@ -17,8 +17,43 @@ public interface HandlerHelper {
      * @return a Link
      */
     @SuppressWarnings("unused")
-    default String constructLink(String route) {
+    default String constructLinkToServer(String route) {
         return getContext().getIzouServerURL().orElse("locahost:80")+"/"+route;
+    }
+
+    /**
+     * constructs a link, falling back to localhost port 80 if no valid izou-server link was found
+     * @param route the route to add to the link, e.g. apps/1
+     * @return a Link
+     */
+    @SuppressWarnings("unused")
+    default String constructLink(String route) {
+        String id = getContext().getAddOns().getAddOn().getID();
+        Optional<AddOnInformation> addOnInformation = getContext().getAddOns().getAddOnInformation(id);
+        return getContext().getIzouServerURL().orElse("locahost:80")+"/"+route;
+    }
+
+    /**
+     * constructs a link, falling back to localhost port 80 if no valid izou-server link was found
+     * @param addOnInformation the addon to link to
+     * @param route the route to add to the link, e.g. apps/1
+     * @return a Link
+     */
+    @SuppressWarnings("unused")
+    default String constructLinkToAddon(AddOnInformation addOnInformation, String route) {
+        //TODO getIzouServerURL() when implemented!
+        String base = getContext().getIzouServerURL().orElse("locahost:80") + "/users/1/izou/1/instance/";
+        String urlWithAddon;
+        Optional<Integer> serverID = addOnInformation.getServerID();
+        if (serverID.isPresent()) {
+            urlWithAddon = base + "apps/" + serverID.get();
+        } else {
+            urlWithAddon = base + "apps/dev/" + addOnInformation.getName();
+        }
+        if (!route.startsWith("/")) {
+            urlWithAddon = urlWithAddon + "/";
+        }
+        return urlWithAddon + route;
     }
 
     /**
@@ -28,17 +63,7 @@ public interface HandlerHelper {
      * @return the response
      */
     default Response stringResponse(String message, int status) {
-        return new Response(status, new HashMap<>(), "text", message.getBytes(Charset.forName("UTF-8")));
-    }
-
-    /**
-     * removes the start from the url
-     * @param start the start to remove
-     * @param url the url to check
-     * @return
-     */
-    default String sliceUrl(String start, String url) {
-
+        return new Response(status, new HashMap<>(), "text/plain", message);
     }
 
     /**

--- a/src/main/java/org/intellimate/izou/sdk/server/HandlerHelper.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/HandlerHelper.java
@@ -16,6 +16,7 @@ public interface HandlerHelper {
      * @param route the route to add to the link, e.g. apps/1
      * @return a Link
      */
+    @SuppressWarnings("unused")
     default String constructLink(String route) {
         return getContext().getIzouServerURL().orElse("locahost:80")+"/"+route;
     }
@@ -28,6 +29,16 @@ public interface HandlerHelper {
      */
     default Response stringResponse(String message, int status) {
         return new Response(status, new HashMap<>(), "text", message.getBytes(Charset.forName("UTF-8")));
+    }
+
+    /**
+     * removes the start from the url
+     * @param start the start to remove
+     * @param url the url to check
+     * @return
+     */
+    default String sliceUrl(String start, String url) {
+
     }
 
     /**

--- a/src/main/java/org/intellimate/izou/sdk/server/HandlerHelper.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/HandlerHelper.java
@@ -1,0 +1,48 @@
+package org.intellimate.izou.sdk.server;
+
+import org.intellimate.izou.sdk.Context;
+import org.intellimate.izou.sdk.util.ContextProvider;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+
+/**
+ * @author LeanderK
+ * @version 1.0
+ */
+public interface HandlerHelper {
+    /**
+     * constructs a link, falling back to localhost port 80 if no valid izou-server link was found
+     * @param route the route to add to the link, e.g. apps/1
+     * @return a Link
+     */
+    default String constructLink(String route) {
+        return getContext().getIzouServerURL().orElse("locahost:80")+"/"+route;
+    }
+
+    /**
+     * constructs the response for a String
+     * @param message the message to print
+     * @param status the status of the message
+     * @return the response
+     */
+    default Response stringResponse(String message, int status) {
+        return new Response(status, new HashMap<>(), "text", message.getBytes(Charset.forName("UTF-8")));
+    }
+
+    /**
+     * returns the context
+     * @return the context
+     */
+    Context getContext();
+
+    /**
+     * checks if the response is null or not valid, throws an InternalServerErrorException if thats the case
+     * @param response the response to check
+     */
+    default void sanityCheck(Response response) {
+        if (response == null  || !response.isValidResponse()) {
+            throw new InternalServerErrorException("App returned illegal response");
+        }
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/InternalServerErrorException.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/InternalServerErrorException.java
@@ -1,0 +1,38 @@
+package org.intellimate.izou.sdk.server;
+
+/**
+ * represents an InternalServerError (500)
+ * @author LeanderK
+ * @version 1.0
+ */
+public class InternalServerErrorException extends RuntimeException {
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     */
+    public InternalServerErrorException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the
+     *                {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                permitted, and indicates that the cause is nonexistent or
+     *                unknown.)
+     * @since 1.4
+     */
+    public InternalServerErrorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/Method.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Method.java
@@ -8,5 +8,5 @@ package org.intellimate.izou.sdk.server;
 //TODO add missing
 @SuppressWarnings("WeakerAccess")
 public enum Method {
-    GET, POST, PUT, PATCH, DELETE
+    GET, POST, PUT, PATCH, DELETE, OPTIONS
 }

--- a/src/main/java/org/intellimate/izou/sdk/server/Method.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Method.java
@@ -1,0 +1,10 @@
+package org.intellimate.izou.sdk.server;
+
+/**
+ * represents the http-methods
+ * @author LeanderK
+ * @version 1.0
+ */
+public enum Method {
+    GET, POST, PUT, PATCH, DELETE
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/Method.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Method.java
@@ -5,6 +5,8 @@ package org.intellimate.izou.sdk.server;
  * @author LeanderK
  * @version 1.0
  */
+//TODO add missing
+@SuppressWarnings("WeakerAccess")
 public enum Method {
     GET, POST, PUT, PATCH, DELETE
 }

--- a/src/main/java/org/intellimate/izou/sdk/server/NotFoundException.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/NotFoundException.java
@@ -1,0 +1,9 @@
+package org.intellimate.izou.sdk.server;
+
+/**
+ * represents a 404 NotFound
+ * @author LeanderK
+ * @version 1.0
+ */
+public class NotFoundException extends RuntimeException {
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/Request.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Request.java
@@ -84,10 +84,13 @@ public class Request implements org.intellimate.izou.server.Request {
             withOutTrailingSlash = withoutQuery;
         }
         String shortString;
-        if (withOutTrailingSlash.startsWith("apps/dev")) {
-            shortString = withOutTrailingSlash.replaceFirst("apps/dev/\\w+", "");
+        if (withOutTrailingSlash.startsWith("/apps/dev")) {
+            shortString = withOutTrailingSlash.replaceFirst("/apps/dev/\\w+", "");
         } else {
-            shortString = withOutTrailingSlash.replaceFirst("apps/\\d+", "");
+            shortString = withOutTrailingSlash.replaceFirst("/apps/\\d+", "");
+        }
+        if (shortString.isEmpty()) {
+            shortString = "/";
         }
         return shortString;
     }

--- a/src/main/java/org/intellimate/izou/sdk/server/Request.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Request.java
@@ -1,5 +1,6 @@
 package org.intellimate.izou.sdk.server;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -11,10 +12,34 @@ import java.util.regex.Matcher;
 public class Request implements org.intellimate.izou.server.Request {
     private final org.intellimate.izou.server.Request request;
     private final Matcher matcher;
+    private final String shortenedUrl;
 
     public Request(org.intellimate.izou.server.Request request, Matcher matcher) {
         this.request = request;
         this.matcher = matcher;
+        shortenedUrl = shortenUrl(request.getUrl());
+    }
+
+    public Request(org.intellimate.izou.server.Request request, Matcher matcher, String shortenedUrl) {
+        this.request = request;
+        this.matcher = matcher;
+        this.shortenedUrl = shortenedUrl;
+    }
+
+    private String shortenUrl(String fullUrl) {
+        String withOutTrailingSlash;
+        if (fullUrl.endsWith("/")) {
+            withOutTrailingSlash = fullUrl.substring(0, fullUrl.length());
+        } else {
+            withOutTrailingSlash = fullUrl;
+        }
+        String shortString;
+        if (withOutTrailingSlash.startsWith("apps/dev")) {
+            shortString = withOutTrailingSlash.replaceFirst("apps/dev/\\w+", "");
+        } else {
+            shortString = withOutTrailingSlash.replaceFirst("apps/\\d+", "");
+        }
+        return shortString;
     }
 
     @Override
@@ -38,7 +63,12 @@ public class Request implements org.intellimate.izou.server.Request {
     }
 
     @Override
-    public byte[] getData() {
+    public int getContentLength() {
+        return request.getContentLength();
+    }
+
+    @Override
+    public InputStream getData() {
         return request.getData();
     }
 
@@ -49,5 +79,17 @@ public class Request implements org.intellimate.izou.server.Request {
      */
     public String getGroup(String name) {
         return matcher.group(name);
+    }
+
+    /**
+     * this string does not contain {@code /apps/id} or {@code /apps/dev/name} and also no slash at the end
+     * @return the shortened url
+     */
+    public String getShortUrl() {
+        return shortenedUrl;
+    }
+
+    public Request setMatcher(Matcher matcher) {
+        return new Request(request, matcher, shortenedUrl);
     }
 }

--- a/src/main/java/org/intellimate/izou/sdk/server/Request.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Request.java
@@ -1,0 +1,53 @@
+package org.intellimate.izou.sdk.server;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+/**
+ * @author LeanderK
+ * @version 1.0
+ */
+public class Request implements org.intellimate.izou.server.Request {
+    private final org.intellimate.izou.server.Request request;
+    private final Matcher matcher;
+
+    public Request(org.intellimate.izou.server.Request request, Matcher matcher) {
+        this.request = request;
+        this.matcher = matcher;
+    }
+
+    @Override
+    public String getUrl() {
+        return request.getUrl();
+    }
+
+    @Override
+    public Map<String, List<String>> getParams() {
+        return request.getParams();
+    }
+
+    @Override
+    public String getMethod() {
+        return request.getMethod();
+    }
+
+    @Override
+    public String getContentType() {
+        return request.getContentType();
+    }
+
+    @Override
+    public byte[] getData() {
+        return request.getData();
+    }
+
+    /**
+     * returns the named group from the regex
+     * @param name the name of the group
+     * @return the resulting capture, or null
+     */
+    public String getGroup(String name) {
+        return matcher.group(name);
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/Request.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Request.java
@@ -1,9 +1,14 @@
 package org.intellimate.izou.sdk.server;
 
+import org.intellimate.izou.identification.AddOnInformation;
+import org.intellimate.izou.sdk.Context;
+
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.*;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 /**
  * @author LeanderK
@@ -13,25 +18,70 @@ public class Request implements org.intellimate.izou.server.Request {
     private final org.intellimate.izou.server.Request request;
     private final Matcher matcher;
     private final String shortenedUrl;
+    private final AddOnInformation source;
+    private final String token;
+    private final Map<String, List<String>> queryParams;
 
-    public Request(org.intellimate.izou.server.Request request, Matcher matcher) {
-        this.request = request;
-        this.matcher = matcher;
-        shortenedUrl = shortenUrl(request.getUrl());
+    public Request(org.intellimate.izou.server.Request request, Matcher matcher, Context context) {
+        this(request, matcher, null, context);
     }
 
-    public Request(org.intellimate.izou.server.Request request, Matcher matcher, String shortenedUrl) {
+    private Request(org.intellimate.izou.server.Request request, Matcher matcher, String shortenedUrl, Context context) {
+        this.request = request;
+        this.matcher = matcher;
+        if (shortenedUrl == null) {
+            this.shortenedUrl = shortenUrl(request.getUrl());
+        } else {
+            this.shortenedUrl = shortenedUrl;
+        }
+        List<String> sourceList = request.getParams().get("app");
+        if (sourceList == null || sourceList.isEmpty()) {
+            source = null;
+        } else {
+            String source = sourceList.get(0);
+            int id = -1;
+            try {
+                id = Integer.parseInt(source);
+            } catch (NumberFormatException e) {}
+            if (id != -1) {
+                this.source = context.getAddOns().getAddOnInformation(id)
+                        .orElse(null);
+            } else {
+                this.source = context.getAddOns().getAddOnInformation(source)
+                        .orElse(null);
+            }
+        }
+        List<String> tokenList = request.getParams().get("token");
+        if (tokenList != null && !tokenList.isEmpty()) {
+            this.token = tokenList.get(0);
+        } else {
+            this.token = null;
+        }
+
+        queryParams = getQueryMap(request.getUrl());
+    }
+
+    public Request(org.intellimate.izou.server.Request request, Matcher matcher, String shortenedUrl,
+                   AddOnInformation source, String token, Map<String, List<String>> queryParams) {
         this.request = request;
         this.matcher = matcher;
         this.shortenedUrl = shortenedUrl;
+        this.source = source;
+        this.token = token;
+        this.queryParams = queryParams;
     }
 
     private String shortenUrl(String fullUrl) {
+        String withoutQuery = fullUrl;
+        int index = fullUrl.indexOf("?");
+        if (index != -1) {
+            withoutQuery = fullUrl.substring(0, index);
+        }
         String withOutTrailingSlash;
-        if (fullUrl.endsWith("/")) {
-            withOutTrailingSlash = fullUrl.substring(0, fullUrl.length());
+        if (withoutQuery.endsWith("/")) {
+            withOutTrailingSlash = withoutQuery.substring(0, fullUrl.length());
         } else {
-            withOutTrailingSlash = fullUrl;
+            withOutTrailingSlash = withoutQuery;
         }
         String shortString;
         if (withOutTrailingSlash.startsWith("apps/dev")) {
@@ -40,6 +90,48 @@ public class Request implements org.intellimate.izou.server.Request {
             shortString = withOutTrailingSlash.replaceFirst("apps/\\d+", "");
         }
         return shortString;
+    }
+
+    private Map<String, List<String>> getQueryMap(String url) {
+        int index = url.indexOf("?");
+        if (index != -1 && index != (url.length() -1)) {
+            String queryParams = url.substring(index + 1, url.length());
+            String[] split = queryParams.split("&");
+
+            return Arrays.stream(split)
+                    .map(argument -> argument.split("="))
+                    .filter(arguments -> arguments.length <= 2)
+                    .filter(arguments -> arguments.length >= 1)
+                    .collect(Collectors.toMap(
+                            (String[] arguments) -> {
+                                try {
+                                    return URLDecoder.decode(arguments[0], "UTF-8");
+                                } catch (UnsupportedEncodingException e) {
+                                    throw new InternalServerErrorException("Unable to decode query parameter: "+arguments[0], e);
+                                }
+                            },
+                            (String[] arguments) -> {
+                                List<String> arrayList = new ArrayList<>();
+                                if (arguments.length == 1) {
+                                    return arrayList;
+                                } else {
+                                    try {
+                                        arrayList.add(URLDecoder.decode(arguments[1], "UTF-8"));
+                                    } catch (UnsupportedEncodingException e) {
+                                        throw new InternalServerErrorException("Unable to decode query parameter: "+arguments[1], e);
+                                    }
+                                    return arrayList;
+                                }
+                            },
+                            (arrayList, arrayList2) -> {
+                                arrayList.addAll(arrayList2);
+                                return arrayList;
+                            }
+                    ));
+
+        } else {
+            return new HashMap<>();
+        }
     }
 
     @Override
@@ -73,6 +165,22 @@ public class Request implements org.intellimate.izou.server.Request {
     }
 
     /**
+     * returns the source of the request, if it came from an app
+     * @return the information about the Addon
+     */
+    public Optional<AddOnInformation> getSource() {
+        return Optional.ofNullable(source);
+    }
+
+    /**
+     * returns the Access token of the app, only present if the app is calling itself!
+     * @return the token if the request comes from the app itself
+     */
+    public Optional<String> getToken() {
+        return Optional.ofNullable(token);
+    }
+
+    /**
      * returns the named group from the regex
      * @param name the name of the group
      * @return the resulting capture, or null
@@ -82,14 +190,19 @@ public class Request implements org.intellimate.izou.server.Request {
     }
 
     /**
-     * this string does not contain {@code /apps/id} or {@code /apps/dev/name} and also no slash at the end
+     * this string does not contain {@code /apps/id} or {@code /apps/dev/name} and also no slash at the end, also no query params
      * @return the shortened url
      */
     public String getShortUrl() {
         return shortenedUrl;
     }
 
+    /**
+     * sets the matcher for the request
+     * @param matcher the matcher
+     * @return the request
+     */
     public Request setMatcher(Matcher matcher) {
-        return new Request(request, matcher, shortenedUrl);
+        return new Request(request, matcher, shortenedUrl, source, token, queryParams);
     }
 }

--- a/src/main/java/org/intellimate/izou/sdk/server/Response.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Response.java
@@ -1,10 +1,20 @@
 package org.intellimate.izou.sdk.server;
 
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
+ * represents an response.
+ * <p>
+ * this class is immutable!
+ * </p>
  * @author LeanderK
  * @version 1.0
  */
@@ -12,17 +22,27 @@ public class Response implements org.intellimate.izou.server.Response {
     private final int status;
     private final Map<String, List<String>> headers;
     private final String contentType;
-    private final byte[] data;
+    private final long dataSize;
+    private final InputStream stream;
 
     public Response() {
-        this(-1, new HashMap<>(), null, null);
+        this(-1, new HashMap<>(), null, -1, null);
+    }
+
+    public Response(int status, Map<String, List<String>> headers, String contentType, String data) {
+        this(status, headers, contentType, data.getBytes(Charset.forName("UTF-8")));
     }
 
     public Response(int status, Map<String, List<String>> headers, String contentType, byte[] data) {
+        this(status, headers, contentType, data.length, new ByteArrayInputStream(data));
+    }
+
+    public Response(int status, Map<String, List<String>> headers, String contentType, long dataSize, InputStream stream) {
         this.status = status;
         this.headers = headers;
         this.contentType = contentType;
-        this.data = data;
+        this.dataSize = dataSize;
+        this.stream = stream;
     }
 
     @Override
@@ -30,9 +50,29 @@ public class Response implements org.intellimate.izou.server.Response {
         return status;
     }
 
+    /**
+     * sets the status
+     * @param status the status to set
+     * @return a new Response with the applied status
+     */
+    @SuppressWarnings("unused")
+    public Response setStaus(int status) {
+        return new Response(status, headers, contentType, dataSize, stream);
+    }
+
     @Override
     public Map<String, List<String>> getHeaders() {
         return headers;
+    }
+
+    /**
+     * sets the headers
+     * @param headers the headers to set
+     * @return a new Response with the applied headers
+     */
+    @SuppressWarnings("unused")
+    public Response setHeaders(Map<String, List<String>> headers) {
+        return new Response(status, headers, contentType, dataSize, stream);
     }
 
     @Override
@@ -40,12 +80,52 @@ public class Response implements org.intellimate.izou.server.Response {
         return contentType;
     }
 
-    @Override
-    public byte[] getData() {
-        return data;
+    /**
+     * sets the content-type
+     * @param contentType the content-type to set
+     * @return a new Response with the applied content-type
+     */
+    @SuppressWarnings("unused")
+    public Response setContentType(String contentType) {
+        return new Response(status, headers, contentType, dataSize, stream);
     }
 
+    @Override
+    public long getDataSize() {
+        return dataSize;
+    }
+
+    @Override
+    public InputStream getData() {
+        return stream;
+    }
+
+    /**
+     * sets the data
+     * @param data the data to set
+     * @return a new Response with the applied data
+     */
+    public Response setData(byte[] data) {
+        return new Response(status, headers, contentType, data.length, new ByteArrayInputStream(data));
+    }
+
+    /**
+     * sets the data
+     * @param dataSize the size of the data
+     * @param stream the stream
+     * @return a new Response with the applied data
+     */
+    @SuppressWarnings("unused")
+    public Response setData(int dataSize, InputStream stream) {
+        return new Response(status, headers, contentType, dataSize, stream);
+    }
+
+    /**
+     * performs basic validity checking for the response
+     * @return true if valid, false if not
+     */
+    @SuppressWarnings("WeakerAccess")
     public boolean isValidResponse() {
-        return status != -1 && contentType != null && !contentType.isEmpty() && data != null && data.length != 0;
+        return status != -1 && contentType != null && !contentType.isEmpty() && dataSize != -1 && stream != null;
     }
 }

--- a/src/main/java/org/intellimate/izou/sdk/server/Response.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Response.java
@@ -1,0 +1,51 @@
+package org.intellimate.izou.sdk.server;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author LeanderK
+ * @version 1.0
+ */
+public class Response implements org.intellimate.izou.server.Response {
+    private final int status;
+    private final Map<String, List<String>> headers;
+    private final String contentType;
+    private final byte[] data;
+
+    public Response() {
+        this(-1, new HashMap<>(), null, null);
+    }
+
+    public Response(int status, Map<String, List<String>> headers, String contentType, byte[] data) {
+        this.status = status;
+        this.headers = headers;
+        this.contentType = contentType;
+        this.data = data;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public byte[] getData() {
+        return data;
+    }
+
+    public boolean isValidResponse() {
+        return status != -1 && contentType != null && !contentType.isEmpty() && data != null && data.length != 0;
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/Route.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Route.java
@@ -14,6 +14,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.aspectj.weaver.tools.cache.SimpleCacheFactory.path;
+
 /**
  * a route in the router
  * @author LeanderK
@@ -173,6 +175,14 @@ public class Route extends AddOnModule implements HandlerHelper, FireEvent {
     @SuppressWarnings("unused")
     public void deleteInternal(Function<Request, Response> handleFunction) {
         handlers.add(new DefaultHandler(context, addOnPackageName, route, Method.DELETE, true, handleFunction));
+    }
+
+    /**
+     * handles all the options-Requests on the route
+     * @param handleFunction the function to use for the options-requests
+     */
+    public void options(Function<Request, Response> handleFunction) {
+        handlers.add(new DefaultHandler(context, addOnPackageName, route, Method.OPTIONS, true, handleFunction));
     }
 
     /**

--- a/src/main/java/org/intellimate/izou/sdk/server/Route.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Route.java
@@ -1,0 +1,131 @@
+package org.intellimate.izou.sdk.server;
+
+import org.intellimate.izou.sdk.Context;
+import org.intellimate.izou.sdk.util.AddOnModule;
+import org.intellimate.izou.sdk.util.FireEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * a route in the router
+ * @author LeanderK
+ * @version 1.0
+ */
+public class Route extends AddOnModule implements HandlerHelper, FireEvent {
+    /**
+     * the regex route
+     */
+    private final String route;
+    private final Pattern pattern;
+    private final List<Handler> handlers = new ArrayList<>();
+    private final Context context;
+    private final String addOnPackageName;
+
+    public Route(Context context, String route, String addOnPackageName) {
+        super(context, addOnPackageName+"."+route);
+        this.context = context;
+        this.route = route;
+        this.pattern = Pattern.compile(route);
+        this.addOnPackageName = addOnPackageName;
+    }
+
+    /**
+     * maybe handles a request
+     * @param request the request
+     * @return the request
+     */
+    Optional<Response> handle(org.intellimate.izou.server.Request request) {
+        Matcher matcher = pattern.matcher(request.getUrl());
+        if (matcher.matches()) {
+            Request internalRequest = new Request(request, matcher);
+            return handlers.stream()
+                    .map(handler -> handler.handle(internalRequest))
+                    .filter(Optional::isPresent)
+                    .findAny()
+                    .orElseThrow(NotFoundException::new);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * returns the current context
+     * @return the current context
+     */
+    public Context getContext() {
+        return context;
+    }
+
+    /**
+     * returns the active route
+     * @return the route
+     */
+    public String getRoute() {
+        return route;
+    }
+
+    /**
+     * handles all the get-Requests on the route
+     * @param handleFunction the function to use for the get-requests
+     */
+    public void get(Function<Request, Response> handleFunction) {
+        handlers.add(new DefaultHandler(context, addOnPackageName, route, Method.GET, handleFunction));
+    }
+
+    /**
+     * handles all the put-Requests on the route
+     * @param handleFunction the function to use for the put-requests
+     */
+    public void put(Function<Request, Response> handleFunction) {
+        handlers.add(new DefaultHandler(context, addOnPackageName, route, Method.PUT, handleFunction));
+    }
+
+    /**
+     * handles all the patch-Requests on the route
+     * @param handleFunction the function to use for the patch-requests
+     */
+    public void patch(Function<Request, Response> handleFunction) {
+        handlers.add(new DefaultHandler(context, addOnPackageName, route, Method.PATCH, handleFunction));
+    }
+
+    /**
+     * handles all the post-Requests on the route
+     * @param handleFunction the function to use for the post-requests
+     */
+    public void post(Function<Request, Response> handleFunction) {
+        handlers.add(new DefaultHandler(context, addOnPackageName, route, Method.POST, handleFunction));
+    }
+
+    /**
+     * handles all the delete-Requests on the route
+     * @param handleFunction the function to use for the delete-requests
+     */
+    public void delete(Function<Request, Response> handleFunction) {
+        handlers.add(new DefaultHandler(context, addOnPackageName, route, Method.DELETE, handleFunction));
+    }
+
+    /**
+     * handles all the Requests on the route
+     * @param handleFunction the function to use for the requests
+     */
+    public void all(Function<Request, Response> handleFunction) {
+        handlers.add(new Handler() {
+            @Override
+            public Optional<Response> handle(Request request) {
+                Response response = handleFunction.apply(request);
+                sanityCheck(response);
+                return Optional.of(response);
+            }
+
+            @Override
+            public Context getContext() {
+                return context;
+            }
+        });
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/Router.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Router.java
@@ -1,6 +1,7 @@
 package org.intellimate.izou.sdk.server;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import org.intellimate.izou.sdk.Context;
 import org.intellimate.izou.server.Request;
@@ -11,11 +12,11 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 /**
- * a simple router
+ * a simple router, please look at {@link org.intellimate.izou.sdk.server.properties.PropertiesRouter} for an example.
  * @author LeanderK
  * @version 1.0
  */
-public class Router implements HandlerHelper {
+public abstract class Router implements HandlerHelper {
     private final String addOnPackageName;
     private List<Route> routes = new ArrayList<>();
     private Map<Class<? extends Exception>, BiFunction<Request, ? extends Exception, Response>> exceptionHandlers = new HashMap<>();
@@ -26,9 +27,9 @@ public class Router implements HandlerHelper {
      * creates a new Router
      * @param context the context to use
      */
-    public Router(Context context, String addOnPackageName) {
+    public Router(Context context) {
         this.context = context;
-        this.addOnPackageName = addOnPackageName;
+        this.addOnPackageName = getClass().getPackage().toString();
 
         exception(InternalServerErrorException.class, (request, e) -> {
             getContext().getLogger().error("an internal error occurred while handling " + request.getUrl(), e);
@@ -47,7 +48,7 @@ public class Router implements HandlerHelper {
     }
 
     public Response handle(org.intellimate.izou.server.Request request) {
-        org.intellimate.izou.sdk.server.Request internalRequest = new org.intellimate.izou.sdk.server.Request(request, null);
+        org.intellimate.izou.sdk.server.Request internalRequest = new org.intellimate.izou.sdk.server.Request(request, null, context);
         Response response = routes.stream()
                 .map(route -> {
                     try {
@@ -79,7 +80,11 @@ public class Router implements HandlerHelper {
                 .findAny()
                 .orElseGet(() -> {
                     context.getLogger().error("en error occured while trying to server request for: " + request.getUrl(), e);
-                    return stringResponse("unknown internalServerError", 500);
+                    ErrorResponse error = ErrorResponse.newBuilder()
+                            .setCode("an internal error occurred while handling " + request.getUrl())
+                            .setDetail(e.getMessage())
+                            .build();
+                    return constructMessageResponse(error, 500);
                 });
         if (response == null || !response.isValidResponse()) {
             return stringResponse("error handling returned illegal response", 500);
@@ -98,14 +103,29 @@ public class Router implements HandlerHelper {
     }
 
     /**
-     * adds a new route.
+     * adds a new route, accessible for all apps (this still depends on the handlers for the methods).
      * <p>
      * Every route starts with a {@code /}! Example {@code /assets/new}.
      * @param regex the regex-route to match
      * @param consumer the consumer used to initialize the route
      */
+    @SuppressWarnings({"WeakerAccess", "unused"})
     public void route(String regex, Consumer<Route> consumer) {
-        Route route = new Route(context, regex, addOnPackageName);
+        Route route = new Route(context, regex, addOnPackageName, false);
+        consumer.accept(route);
+        routes.add(route);
+    }
+
+    /**
+     * adds a new route only accessible with the authentication of this app
+     * <p>
+     * Every route starts with a {@code /}! Example {@code /assets/new}.
+     * @param regex the regex-route to match
+     * @param consumer the consumer used to initialize the route
+     */
+    @SuppressWarnings("WeakerAccess")
+    public void routeInternal(String regex, Consumer<Route> consumer) {
+        Route route = new Route(context, regex, addOnPackageName, true);
         consumer.accept(route);
         routes.add(route);
     }
@@ -125,15 +145,19 @@ public class Router implements HandlerHelper {
     public <T extends Exception> void exception(Class<T> clazz, BiFunction<Request, T, ErrorResponse> handleFunction, int status) {
         exception(clazz, (request, t) -> {
             ErrorResponse errorResponse = handleFunction.apply(request, t);
-            String response = null;
-            try {
-                response = PRINTER.print(errorResponse);
-            } catch (InvalidProtocolBufferException e) {
-                getContext().getLogger().debug("unable to print error-message", e);
-                return new Response(status, new HashMap<>(), "text/plain", "unable to print error-message, " + e.getMessage());
-            }
-            return new Response(status, new HashMap<>(), "application/json", response);
+            return constructMessageResponse(errorResponse, status);
         });
+    }
+
+    private Response constructMessageResponse(Message message, int status) {
+        String response;
+        try {
+            response = PRINTER.print(message);
+        } catch (InvalidProtocolBufferException e) {
+            getContext().getLogger().debug("unable to print error-message", e);
+            return new Response(status, new HashMap<>(), "text/plain", "unable to print error-message, " + e.getMessage());
+        }
+        return new Response(status, new HashMap<>(), "application/json", response);
     }
 
 }

--- a/src/main/java/org/intellimate/izou/sdk/server/Router.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/Router.java
@@ -1,0 +1,100 @@
+package org.intellimate.izou.sdk.server;
+
+import org.intellimate.izou.sdk.Context;
+import org.intellimate.izou.server.*;
+import org.intellimate.izou.server.Request;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * a simple router
+ * @author LeanderK
+ * @version 1.0
+ */
+public class Router implements HandlerHelper {
+    private final String addOnPackageName;
+    private List<Route> routes = new ArrayList<>();
+    private Map<Class<? extends Exception>, BiFunction<Request, ? extends Exception, Response>> exceptionHandlers = new HashMap<>();
+    private final Context context;
+
+    /**
+     * creates a new Router
+     * @param context the context to use
+     */
+    public Router(Context context, String addOnPackageName) {
+        this.context = context;
+        this.addOnPackageName = addOnPackageName;
+    }
+
+    public Response handle(org.intellimate.izou.server.Request request) {
+        Response response = routes.stream()
+                .map(route -> {
+                    try {
+                        return route.handle(request);
+                    } catch (Exception e) {
+                        return Optional.of(handleException(e, request));
+                    }
+                })
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findAny()
+                .orElseGet(() -> stringResponse("no matching routes found", 404));
+        sanityCheck(response);
+        return response;
+    }
+
+    /**
+     * handles the thrown exceptions while generating content
+     * @param e the exception
+     * @return a response
+     */
+    private Response handleException(Exception e, org.intellimate.izou.server.Request request) {
+        Response response = exceptionHandlers.entrySet().stream()
+                .filter(entry -> entry.getKey().isAssignableFrom(e.getClass()))
+                .map(entry -> {
+                    BiFunction value = entry.getValue();
+                    return (Response) value.apply(request, e);
+                })
+                .findAny()
+                .orElseGet(() -> {
+                    context.getLogger().error("en error occured while trying to server request for: " + request.getUrl(), e);
+                    return stringResponse("unknown internalServerError", 500);
+                });
+        if (response == null || !response.isValidResponse()) {
+            return stringResponse("error handling returned illegal response", 500);
+        } else {
+            return response;
+        }
+    }
+
+    /**
+     * returns the instance of Context
+     *
+     * @return the instance of Context
+     */
+    public Context getContext() {
+        return context;
+    }
+
+    /**
+     * adds a new route
+     * @param regex the regex-route to match
+     * @param consumer the consumer used to initialize the route
+     */
+    public void route(String regex, Consumer<Route> consumer) {
+        Route route = new Route(context, regex, addOnPackageName);
+        consumer.accept(route);
+        routes.add(route);
+    }
+
+    /**
+     * registers an Exception to catch and handle
+     * @param handleFunction the function to call when an exception was triggered
+     */
+    public <T extends Exception> void exception(Class<T> clazz, BiFunction<Request, T, Response> handleFunction) {
+        exceptionHandlers.put(clazz, handleFunction);
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/SDKRouter.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/SDKRouter.java
@@ -1,0 +1,98 @@
+package org.intellimate.izou.sdk.server;
+
+import freemarker.template.*;
+import org.intellimate.izou.identification.AddOnInformation;
+import org.intellimate.izou.sdk.Context;
+import org.intellimate.izou.sdk.server.properties.PropertiesRouter;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.*;
+
+/**
+ * the router active in the sdk
+ * @author LeanderK
+ * @version 1.0
+ */
+public class SDKRouter extends Router {
+    private final Configuration cfg;
+
+    /**
+     * creates a new Router
+     *
+     * @param context          the context to use
+     */
+    public SDKRouter(Context context) {
+        super(context);
+
+        cfg = new Configuration(new Version(2,3,24));
+        cfg.setClassForTemplateLoading(SDKRouter.class, "server.freemarker");
+        cfg.setDefaultEncoding("UTF-8");
+        cfg.setLocale(Locale.US);
+        cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+
+        route("/template/properties", route -> {
+            route.get(this::getHtmlBaseFile);
+        });
+
+        route("/", route -> {
+            route.get(this::getResponse);
+        });
+
+        route("/index.html", route -> {
+            route.get(this::getResponse);
+        });
+    }
+
+    private Response getResponse(Request request) {
+        URL resource = SDKRouter.class.getResource("greetings.html");
+        try {
+            File file = new File(resource.toURI());
+            return sendFile(request, file);
+        } catch (URISyntaxException e) {
+            throw new InternalServerErrorException("Unable to open file", e);
+        }
+    }
+
+    private Response getHtmlBaseFile(Request request) {
+        AddOnInformation addOnInformation = request.getSource()
+                .orElseThrow(() -> new BadRequestException("this route is only intended for apps"));
+
+        List<String> tokenList = request.getParams().get("token");
+        if (tokenList == null || tokenList.isEmpty()) {
+            throw new BadRequestException("query parameter token is missing");
+        }
+        String token = tokenList.get(0);
+        if (token == null || token.isEmpty()) {
+            throw new BadRequestException("query parameter token is missing");
+        }
+
+        String urlProperties = constructLinkToAddon(addOnInformation, "/properties");
+        String urlDescription = constructLinkToAddon(addOnInformation, "/description");
+
+        Map<String, Object> input = new HashMap<String, Object>();
+        input.put("app_name", addOnInformation.getName());
+        input.put("url_properties", urlProperties);
+        input.put("url_description", urlDescription);
+        input.put("token", token);
+
+        Template template;
+        try {
+            template = cfg.getTemplate("properties.ftl");
+        } catch (IOException e) {
+            throw new InternalServerErrorException("unable to load template", e);
+        }
+
+        StringWriter stringWriter = new StringWriter();
+        try {
+            template.process(input, stringWriter);
+        } catch (TemplateException | IOException e) {
+            throw new InternalServerErrorException("an error occured while templating", e);
+        }
+        String html = stringWriter.toString();
+        return new Response(200, new HashMap<>(), "text/html", html);
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/server/SDKRouter.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/SDKRouter.java
@@ -29,7 +29,7 @@ public class SDKRouter extends Router {
         super(context);
 
         cfg = new Configuration(new Version(2,3,24));
-        cfg.setClassForTemplateLoading(SDKRouter.class, "server.freemarker");
+        cfg.setClassForTemplateLoading(SDKRouter.class, "server/freemarker");
         cfg.setDefaultEncoding("UTF-8");
         cfg.setLocale(Locale.US);
         cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
@@ -48,7 +48,7 @@ public class SDKRouter extends Router {
     }
 
     private Response getResponse(Request request) {
-        URL resource = SDKRouter.class.getResource("greetings.html");
+        URL resource = getClass().getClassLoader().getResource("server/static/greetings.html");
         try {
             File file = new File(resource.toURI());
             return sendFile(request, file);
@@ -74,7 +74,7 @@ public class SDKRouter extends Router {
         String urlDescription = constructLinkToAddon(addOnInformation, "/description");
 
         Map<String, Object> input = new HashMap<String, Object>();
-        input.put("app_name", addOnInformation.getName());
+        input.put("app_name", addOnInformation.getArtifactID());
         input.put("url_properties", urlProperties);
         input.put("url_description", urlDescription);
         input.put("token", token);

--- a/src/main/java/org/intellimate/izou/sdk/server/properties/PropertiesRouter.java
+++ b/src/main/java/org/intellimate/izou/sdk/server/properties/PropertiesRouter.java
@@ -1,0 +1,145 @@
+package org.intellimate.izou.sdk.server.properties;
+
+import com.google.common.io.ByteStreams;
+import org.intellimate.izou.identification.AddOnInformation;
+import org.intellimate.izou.sdk.Context;
+import org.intellimate.izou.sdk.server.*;
+
+import java.io.*;
+import java.net.URLEncoder;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+/**
+ * the default router used for serving the default-properties file.
+ * @author LeanderK
+ * @version 1.0
+ */
+public class PropertiesRouter extends Router {
+    private Lock writeLock = new ReentrantLock();
+    private final Consumer<File> validatorFunction;
+    @SuppressWarnings("WeakerAccess")
+    protected AddOnInformation addOnInformation;
+
+
+    /**
+     * creates a new Router
+     *
+     * @param context          the context to use
+     * @param validatorFunction can be provided to check the syntax of the temporary submitted file,
+     *                          should return empty if valid, or an exception if not
+     *                          (the server will display the detail if it is an BadRequest).
+     *
+     */
+    @SuppressWarnings("WeakerAccess")
+    public PropertiesRouter(Context context, Consumer<File> validatorFunction) {
+        super(context);
+        this.validatorFunction = validatorFunction;
+
+        addOnInformation = context.getAddOns().getAddOnInformation("org.intellimate.izou.sdk")
+                .orElse(null);
+
+        init();
+    }
+
+    /**
+     * creates a new Router
+     *
+     * @param context          the context to use
+     */
+    public PropertiesRouter(Context context) {
+        this(context, file -> Optional.empty());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    protected void init() {
+        routeInternal("/properties", route -> {
+            route.get(request -> {
+                File propertiesFile = getContext().getPropertiesAssistant().getPropertiesFile();
+                return sendFile(request, propertiesFile)
+                        .setContentType("text/plain");
+            });
+
+            route.patch(this::patchConfigFile);
+        });
+
+        routeInternal("/", route -> {
+            route.get(this::redirect);
+        });
+
+        routeInternal("/index.html", route -> {
+            route.get(this::redirect);
+        });
+    }
+
+    /**
+     * creates the redirect to the
+     * @param request the request to handle
+     * @return the redirect
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected Response redirect(Request request) {
+        if (addOnInformation == null) {
+            throw new InternalServerErrorException("Unable to get AddOnInformation for SDK");
+        }
+        String redirect = constructLinkToAddon(addOnInformation, "/");
+        redirect = redirect + "?token=" + request.getToken()
+                .orElseThrow(() -> new BadRequestException("unable to extract authentication token"));
+        return createRedirect(redirect);
+    }
+
+    /**
+     * the logic for the patch-operation on the config-file
+     * @param request the request to work on
+     * @return a response
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected Response patchConfigFile(Request request) {
+        if (!request.getContentType().equals("text/plain")) {
+            throw new BadRequestException("Content type must be: text/plain");
+        }
+        boolean locked = writeLock.tryLock();
+        if (!locked) {
+            throw new BadRequestException("Server is already processing another request");
+        }
+        FileOutputStream fileOutputStream = null;
+        File tempFile = null;
+        try {
+            File propertiesDir = getContext().getPropertiesAssistant().getPropertiesFile().getParentFile();
+            tempFile = new File(propertiesDir, "default.properties.tmp");
+            if (!tempFile.exists()) {
+                tempFile.createNewFile();
+            }
+            fileOutputStream = new FileOutputStream(tempFile);
+            long copied = ByteStreams.copy(request.getData(), fileOutputStream);
+            if (copied != request.getContentLength()) {
+                throw new BadRequestException("Actual size does not match advertised size");
+            }
+            validatorFunction.accept(tempFile);
+            File propertiesFile = getContext().getPropertiesAssistant().getPropertiesFile();
+            Files.copy(tempFile.toPath(), propertiesFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return sendFile(request, propertiesFile)
+                    .setContentType("text/plain");
+        } catch (FileNotFoundException e) {
+            throw new InternalServerErrorException("unable to create temp-file", e);
+        } catch (IOException e) {
+            throw new InternalServerErrorException("an internal server-error occured while saving the properties file", e);
+        } finally {
+            writeLock.unlock();
+            if (tempFile != null) {
+                tempFile.delete();
+            }
+            if (fileOutputStream != null) {
+                try {
+                    fileOutputStream.close();
+                } catch (IOException e) {
+                    getContext().getLogger().error("unable to close OutputStream", e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/intellimate/izou/sdk/util/ResourceUser.java
+++ b/src/main/java/org/intellimate/izou/sdk/util/ResourceUser.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 //TODO: Leander the return type optional is really unnecessary, i don't think the information resulting from it is
 // useful. We should implement the tip and return CompletableFuture and log if there was an error obtaining the ID.
 // The question is whether to archive this without breaking backwards compatibility (might turn really ugly and i like
-// the current method name)
+// the current method name) - Leander: i know, but backward-compatibility is really bad here (no overloading based on return type)
 public interface ResourceUser extends ContextProvider, Identifiable {
     /**
      * generates the specified resource from the first matching ResourceBuilder (use the ID if you want to be sure).

--- a/src/main/resources/server/freemarker/properties.ftl
+++ b/src/main/resources/server/freemarker/properties.ftl
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en" style="height: 100%;">
+<head>
+    <meta charset="UTF-8">
+    <title>${app_name} Properties</title>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.4.1/showdown.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+            $.ajaxSetup({
+                        'headers':{
+                            'Authorization':'Bearer ${token}'
+                        }
+                    }
+            );
+            generateMarkdown();
+            loadPropertyFile();
+        });
+
+        function generateMarkdown(data) {
+            var target = document.getElementById('description');
+            var converter = new showdown.Converter();
+            target.innerHTML = converter.makeHtml(data);
+        }
+
+        function loadPropertyFile() {
+            $("#property").load("${url_properties}", function(responseTxt, statusTxt, xhr){
+                if(statusTxt == "success"){
+                    $("#errorResponse").hide();
+                }
+                if(statusTxt == "error") {
+                    handleError(xhr);
+                }
+            });
+        }
+
+        function loadDescription() {
+            $.ajax({
+                url : '${url_description}',
+                data : data,
+                type : 'GET',
+                contentType : 'text/plain',
+                success: function(data) {
+                    generateMarkdown(data)
+                },
+                error: function(xhr) {
+                    handleError(xhr);
+                }
+            });
+        }
+
+        function savePropertyFile() {
+            var data = $("#property").val();
+            $.ajax({
+                url : '${url_properties}',
+                data : data,
+                type : 'PATCH',
+                contentType : 'text/plain',
+                success: function() {
+                        $("#errorResponse").hide();
+                },
+                error: function(xhr) {
+                        handleError(xhr);
+                }
+            });
+        }
+
+        function handleError(xhr) {
+            $("#errorResponse").show();
+            if (xhr.status != 400) {
+                $("#errorResponse").text("An unexpected Error occured: " + xhr.status + ": " + xhr.statusText)
+            } else {
+                var errorResponse = JSON.parse(responseTxt);
+                $("#errorResponse").text("Unable to save the input. Server returned: " + errorResponse.detail);
+            }
+        }
+    </script>
+</head>
+
+<body style="height: 100%;">
+    <div style="display: none">
+        <p id="sourceDesc">${description}</p>
+    </div>
+    <div style="width:800px; margin:0 auto; height: 100%;">
+        <div id="description"></div>
+        <div><p id="errorResponse" style="display: none; color: Red; font-weight: bold;">Error</p></div>
+        <textarea id="property" style="resize: none; width: 100%; height: 80%;">
+        </textarea>
+        <button type="button" onclick="savePropertyFile()">Save</button>
+    </div>
+</body>
+</html>

--- a/src/main/resources/server/static/greetings.html
+++ b/src/main/resources/server/static/greetings.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Izou SDK</title>
+</head>
+<body>
+<p>Hello, I am the Izou-SDK<br>
+    I don't need to be configured, i am just working out of the box.<br>
+    Have a good day!</p>
+</body>
+</html>


### PR DESCRIPTION
#### This pull-request adds full support for the upcoming cloud-infrastructure

please visit intellimate/Izou#52 for further information about the motivation.

This pull request introduces the package `server` to the SDK which contains an simple rest-compatible server-framework used for answering requests from the router.

package `server`:
- `BadRequestException`: this exception can be thrown inside the routing-handlers to signal an BadRequest (400)
- `DefaultHandler`: the default implementation of the Handler-interface which checks for the correct method on handle
- `Handler`: the handler is a simple functional interface called by `Route` when the route matches, it can either return an response or declare itself for responsible
- `HandlerHelper`: contains various utility methods for handling requests
- `InternalServerErrorException`: his exception can be thrown inside the routing-handlers to signal an InternalServerError (500)
- `Method`: this enum represents the different commonly used methods for http-requests
- `NotFoundException`: this exception can be thrown inside the routing-handlers to signal an NotFound (404)
- `Request`: this class implements the Request interface from Izou and extends it with various useful functionality
- `Response`: an Response implementation and various useful methods
- `Route`: this class represents a single route in the Router, e.g. /static
- `Router`: this class gets called in the sdk when an request from the server was made. The Add-on can specify multiple routes and error-handlers and the router processes the request accordingly.
- `SDKRouter`: the Router for the SDK, it also serves as an example-implementation. It servers an static html file on index and provides an html file used to render the properties-files for other addons on /template/properties
- `PropertiesRouter`: the default Router for addons. It forwards calls on `/` oder `/index.html` to /template/properties of the SDK with some query parameters to populate the template. It also has an endpoint for the actual properties-file and a (optional) markdown description of it which will be rendered by /template/properties from the SDK.

package `util`:
- `ResourceUser`: clarified TODO

package `add-on`
- `AddOn`: updated to the new interface wich includes the handling of requests and links it to the default implementation (PropertiesRouter)

package `sdk`:
changes:
- `Context`: reflected changes in the Interface specified in Izou

added:
- `AddOnImpl`: the SDK now needs an AddonImplementation to serve the http-requests.

some non-java changes:
added the necessary html-files to the resources folder and updated the pom.xml
